### PR TITLE
Fix average contour normal bug

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@v1
       - name: prep
         run: |
+             git config --global --add safe.directory '*'
              cp -R ./docker/builders/mxe /scratch
              cp -R . /dcma
              ./scripts/enable_swapfile.sh
@@ -80,6 +81,7 @@ jobs:
       - uses: actions/checkout@v1
       - name: prep
         run: |
+             git config --global --add safe.directory '*'
              cp -R ./docker/builders/ci /scratch
              cp -R . /dcma
              ./scripts/enable_swapfile.sh
@@ -125,6 +127,7 @@ jobs:
       - uses: actions/checkout@v1
       - name: prep
         run: |
+             git config --global --add safe.directory '*'
              cp -R ./docker/builders/ci /scratch
              cp -R . /dcma
              ./scripts/enable_swapfile.sh
@@ -173,6 +176,7 @@ jobs:
       - uses: actions/checkout@v1
       - name: prep
         run: |
+             git config --global --add safe.directory '*'
              cp -R ./docker/builders/ci /scratch
              cp -R . /dcma
              ./scripts/enable_swapfile.sh
@@ -218,6 +222,7 @@ jobs:
       - uses: actions/checkout@v1
       - name: prep
         run: |
+             git config --global --add safe.directory '*'
              cp -R . ~/dcma
              export DEBIAN_FRONTEND="noninteractive"
              sudo apt-get update --yes
@@ -277,6 +282,7 @@ jobs:
       - uses: actions/checkout@v1
       - name: prep
         run: |
+             git config --global --add safe.directory '*'
              cp -R . ~/dcma
              export DEBIAN_FRONTEND="noninteractive"
              sudo apt-get update --yes
@@ -336,6 +342,7 @@ jobs:
       - uses: actions/checkout@v1
       - name: prep
         run: |
+             git config --global --add safe.directory '*'
              cp -R . ~/dcma
              export DEBIAN_FRONTEND="noninteractive"
              sudo apt-get update --yes

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,6 @@ jobs:
       - uses: actions/checkout@v1
       - name: prep
         run: |
-             git config --global --add safe.directory '*'
              cp -R ./docker/builders/mxe /scratch
              cp -R . /dcma
              ./scripts/enable_swapfile.sh
@@ -81,7 +80,6 @@ jobs:
       - uses: actions/checkout@v1
       - name: prep
         run: |
-             git config --global --add safe.directory '*'
              cp -R ./docker/builders/ci /scratch
              cp -R . /dcma
              ./scripts/enable_swapfile.sh
@@ -127,7 +125,6 @@ jobs:
       - uses: actions/checkout@v1
       - name: prep
         run: |
-             git config --global --add safe.directory '*'
              cp -R ./docker/builders/ci /scratch
              cp -R . /dcma
              ./scripts/enable_swapfile.sh
@@ -176,7 +173,6 @@ jobs:
       - uses: actions/checkout@v1
       - name: prep
         run: |
-             git config --global --add safe.directory '*'
              cp -R ./docker/builders/ci /scratch
              cp -R . /dcma
              ./scripts/enable_swapfile.sh
@@ -222,7 +218,6 @@ jobs:
       - uses: actions/checkout@v1
       - name: prep
         run: |
-             git config --global --add safe.directory '*'
              cp -R . ~/dcma
              export DEBIAN_FRONTEND="noninteractive"
              sudo apt-get update --yes
@@ -282,7 +277,6 @@ jobs:
       - uses: actions/checkout@v1
       - name: prep
         run: |
-             git config --global --add safe.directory '*'
              cp -R . ~/dcma
              export DEBIAN_FRONTEND="noninteractive"
              sudo apt-get update --yes
@@ -342,7 +336,6 @@ jobs:
       - uses: actions/checkout@v1
       - name: prep
         run: |
-             git config --global --add safe.directory '*'
              cp -R . ~/dcma
              export DEBIAN_FRONTEND="noninteractive"
              sudo apt-get update --yes

--- a/src/Operations/ConvertContoursToMeshes.cc
+++ b/src/Operations/ConvertContoursToMeshes.cc
@@ -202,7 +202,14 @@ bool ConvertContoursToMeshes(Drover &DICOM_data,
     if(std::regex_match(MethodStr, direct_regex)){
         // Identify the unique planes.
         //const auto est_cont_normal = cc.contours.front().Estimate_Planar_Normal();
-        const auto est_cont_normal = Average_Contour_Normals(cc_ref);
+        const auto est_cont_normal = [&]() {
+            auto est_cont_normal = Average_Contour_Normals(cc_ref);
+            if(!est_cont_normal.isfinite()) {
+                est_cont_normal = cc_ref.front().get().contours.front().Estimate_Planar_Normal();
+            };
+            return est_cont_normal;
+        }();
+
         const auto contour_sep_eps = 0.005;
         auto ucps = Unique_Contour_Planes(cc_ref, est_cont_normal, contour_sep_eps);
         if(ucps.size() < 2){


### PR DESCRIPTION
If I import three of the exact same contours (but with a different position so that they are not on the same plane), ``Average_Contour_Normals(cc_ref)`` will return a vector of three NaN values.

This gives "Unable to handle single contour planes at this time." in the terminal which stops meshing algorithm.

Checks:
- add in another contour alongside those 3 that is different: problem is fixed, we get a finite contour normal.

Fix:
- if contour normal is not finite, just take the contour normal of the first contour in the list.