### PR TITLE
Upgraded CreateCustomContour, Fixed an N-to-N bug which results in open meshes in pathalogical cases

### DIFF
--- a/src/Operations/CreateCustomContour.cc
+++ b/src/Operations/CreateCustomContour.cc
@@ -10,6 +10,8 @@
 
 #include "CreateCustomContour.h"
 
+using namespace std;
+
 OperationDoc OpArgDocCreateCustomContour(){
     OperationDoc out;
     out.name = "CreateCustomContour";
@@ -61,56 +63,88 @@ bool CreateCustomContour(Drover &DICOM_data,
     YLOGINFO("The Y values are " << YValues);
     YLOGINFO("The Z values are " << ZValues);
 
-    contour_of_points<double> cop;
     contour_collection<double> cc;
 
-    cop.closed = true;
+    vector<string> x_contours = SplitString(XValues, "|");
+    vector<string> y_contours = SplitString(YValues, "|");
+    vector<string> z_contours = SplitString(ZValues, "|");
+    
 
-    std::vector<double> x_values = ValueStringToDoubleList(XValues);
-    std::vector<double> y_values = ValueStringToDoubleList(YValues);
-    std::vector<double> z_values = ValueStringToDoubleList(ZValues);
-
-    if(x_values.size()!=y_values.size()||y_values.size()!=z_values.size()) {
-        YLOGWARN("Each list must have the same number of numbers");
+    if(x_contours.size()!=y_contours.size()||y_contours.size()!=z_contours.size()) {
+        YLOGWARN("Ensure same number of contours for each dimension");
         return true;
     }
 
-    if(x_values.size() < 3) {
-        YLOGWARN("We require more than 3 points to be in a contour");
+    if(x_contours.size() < 1) {
+        YLOGWARN("We require that there is at least one contour.");
         return true;
     }
-
-    for(int i = 0; i < x_values.size(); i++) {
-        const vec3<double> p(static_cast<double>(x_values[i]), 
-                            static_cast<double>(y_values[i]),
-                            static_cast<double>(z_values[i]));
-        cop.points.emplace_back(p);
-    }
-    cop.metadata["ROILabel"] = ROILabel;
-
-    cc.contours.emplace_back(cop);
 
     DICOM_data.Ensure_Contour_Data_Allocated();
+    
+    vector<vector<double>> x_cops;
+    vector<vector<double>> y_cops;
+    vector<vector<double>> z_cops;
+
+    for(int i = 0; i < x_contours.size(); i++) {
+        vector<string> x_cop_string = SplitString(x_contours[i], " ");
+        vector<string> y_cop_string = SplitString(y_contours[i], " ");
+        vector<string> z_cop_string = SplitString(z_contours[i], " ");
+        if(x_cop_string.size()!=y_cop_string.size()||y_cop_string.size()!=z_cop_string.size()) {
+            YLOGWARN("Ensure each contour has the same number of points for each dimension");
+        }
+        if(x_cop_string.size() < 3) {
+            YLOGWARN("Each contour must have at least 3 points");
+        }
+        vector<double> x_cop;
+        vector<double> y_cop;
+        vector<double> z_cop;
+        for(int j = 0; j < x_cop_string.size(); j++) {
+            try {
+                x_cop.emplace_back(stod(x_cop_string[j]));
+                y_cop.emplace_back(stod(y_cop_string[j]));
+                z_cop.emplace_back(stod(z_cop_string[j]));
+                string error_message = "Invalid Input";
+            } catch(string error_message) {
+                return true;
+            }
+        }
+        x_cops.emplace_back(x_cop);
+        y_cops.emplace_back(y_cop);
+        z_cops.emplace_back(z_cop);
+    }
+
+    for(int i = 0; i < x_cops.size(); i++) {
+        contour_of_points<double> cop;
+        for(int j = 0; j < x_cops[i].size(); j++) {
+            const vec3<double> p(static_cast<double>(x_cops[i][j]),
+                                static_cast<double>(y_cops[i][j]),
+                                static_cast<double>(z_cops[i][j]));
+            cop.points.emplace_back(p);
+        }
+        cop.closed = true;
+        cop.metadata["ROILabel"] = ROILabel;
+        cc.contours.emplace_back(cop);
+    }
+
     DICOM_data.contour_data->ccs.emplace_back(cc);
     return true;
 }
 
-std::vector<double> ValueStringToDoubleList(std::string input) {
-    std::vector<double> values;
+std::vector<string> SplitString(std::string input, std::string delimiter) {
+    vector<string> values;
     size_t pos = 0;
-    std::string delimiter = " ";
-    std::string token;
+    string token;
     while ((pos = input.find(delimiter)) != std::string::npos) {
         token = input.substr(0, pos);
         try {
-            values.emplace_back(stod(token));
-            std::string error_message = "Invalid Input";
-        } catch(std::string error_message) {
-            YLOGWARN(error_message);
-            return std::vector<double>();
+            values.emplace_back(token);
+            string error_message = "Invalid Input";
+        } catch(string error_message) {
+            return std::vector<string>();
         }
         input.erase(0, pos + delimiter.length());
     }
+    values.emplace_back(input);
     return values;
 }
-

--- a/src/Operations/CreateCustomContour.cc
+++ b/src/Operations/CreateCustomContour.cc
@@ -3,14 +3,12 @@
 
 #include <list>
 #include <map>
-#include <string>
+#include <std::string>
 
 #include "../Structs.h"
 #include "YgorLog.h"
 
 #include "CreateCustomContour.h"
-
-using namespace std;
 
 OperationDoc OpArgDocCreateCustomContour(){
     OperationDoc out;
@@ -27,19 +25,19 @@ OperationDoc OpArgDocCreateCustomContour(){
 
     out.args.emplace_back();
     out.args.back().name = "XValues";
-    out.args.back().desc = "List of X coordinates of the points in the contour";
+    out.args.back().desc = "List of contours separated by | character, where each countour is a list of doubles separated by spaces. Contains x-values";
     out.args.back().default_val = "0";
     out.args.back().expected = true;
 
     out.args.emplace_back();
     out.args.back().name = "YValues";
-    out.args.back().desc = "List of Y coordinates of the points in the contour";
+    out.args.back().desc = "List of contours separated by | character, where each countour is a list of doubles separated by spaces. Contains y-values";
     out.args.back().default_val = "0";
     out.args.back().expected = true;
 
     out.args.emplace_back();
     out.args.back().name = "ZValues";
-    out.args.back().desc = "List of Z coordinates of the points in the contour";
+    out.args.back().desc = "List of contours separated by | character, where each countour is a list of doubles separated by spaces. Contains z-values";
     out.args.back().default_val = "0";
     out.args.back().expected = true;
     return out;
@@ -65,9 +63,9 @@ bool CreateCustomContour(Drover &DICOM_data,
 
     contour_collection<double> cc;
 
-    vector<string> x_contours = SplitString(XValues, "|");
-    vector<string> y_contours = SplitString(YValues, "|");
-    vector<string> z_contours = SplitString(ZValues, "|");
+    std::vector<std::string> x_contours = SplitString(XValues, "|");
+    std::vector<std::string> y_contours = SplitString(YValues, "|");
+    std::vector<std::string> z_contours = SplitString(ZValues, "|");
     
 
     if(x_contours.size()!=y_contours.size()||y_contours.size()!=z_contours.size()) {
@@ -82,30 +80,30 @@ bool CreateCustomContour(Drover &DICOM_data,
 
     DICOM_data.Ensure_Contour_Data_Allocated();
     
-    vector<vector<double>> x_cops;
-    vector<vector<double>> y_cops;
-    vector<vector<double>> z_cops;
+    std::vector<std::vector<double>> x_cops;
+    std::vector<std::vector<double>> y_cops;
+    std::vector<std::vector<double>> z_cops;
 
     for(int i = 0; i < x_contours.size(); i++) {
-        vector<string> x_cop_string = SplitString(x_contours[i], " ");
-        vector<string> y_cop_string = SplitString(y_contours[i], " ");
-        vector<string> z_cop_string = SplitString(z_contours[i], " ");
+        std::vector<std::string> x_cop_string = SplitString(x_contours[i], " ");
+        std::vector<std::string> y_cop_string = SplitString(y_contours[i], " ");
+        std::vector<std::string> z_cop_string = SplitString(z_contours[i], " ");
         if(x_cop_string.size()!=y_cop_string.size()||y_cop_string.size()!=z_cop_string.size()) {
             YLOGWARN("Ensure each contour has the same number of points for each dimension");
         }
         if(x_cop_string.size() < 3) {
             YLOGWARN("Each contour must have at least 3 points");
         }
-        vector<double> x_cop;
-        vector<double> y_cop;
-        vector<double> z_cop;
+        std::vector<double> x_cop;
+        std::vector<double> y_cop;
+        std::vector<double> z_cop;
         for(int j = 0; j < x_cop_string.size(); j++) {
             try {
                 x_cop.emplace_back(stod(x_cop_string[j]));
                 y_cop.emplace_back(stod(y_cop_string[j]));
                 z_cop.emplace_back(stod(z_cop_string[j]));
-                string error_message = "Invalid Input";
-            } catch(string error_message) {
+                std::string error_message = "Invalid Input";
+            } catch(std::string error_message) {
                 return true;
             }
         }
@@ -131,17 +129,17 @@ bool CreateCustomContour(Drover &DICOM_data,
     return true;
 }
 
-std::vector<string> SplitString(std::string input, std::string delimiter) {
-    vector<string> values;
+std::vector<std::string> SplitString(std::string input, std::string delimiter) {
+    std::vector<std::string> values;
     size_t pos = 0;
-    string token;
+    std::string token;
     while ((pos = input.find(delimiter)) != std::string::npos) {
         token = input.substr(0, pos);
         try {
             values.emplace_back(token);
-            string error_message = "Invalid Input";
-        } catch(string error_message) {
-            return std::vector<string>();
+            std::string error_message = "Invalid Input";
+        } catch(std::string error_message) {
+            return std::vector<std::string>();
         }
         input.erase(0, pos + delimiter.length());
     }

--- a/src/Operations/CreateCustomContour.cc
+++ b/src/Operations/CreateCustomContour.cc
@@ -3,7 +3,6 @@
 
 #include <list>
 #include <map>
-#include <std::string>
 
 #include "../Structs.h"
 #include "YgorLog.h"

--- a/src/Operations/CreateCustomContour.h
+++ b/src/Operations/CreateCustomContour.h
@@ -15,4 +15,4 @@ bool CreateCustomContour(Drover &DICOM_data,
                     std::map<std::string, std::string>& /*InvocationMetadata*/,
                     const std::string& FilenameLex);
 
-std::vector<double> ValueStringToDoubleList(std::string input);
+std::vector<std::string> SplitString(std::string input, std::string delimiter);

--- a/src/Simple_Meshing.cc
+++ b/src/Simple_Meshing.cc
@@ -646,14 +646,17 @@ Minimally_Amalgamate_Contours(
             auto a_v1_it = std::prev(std::end(amal.points));
             auto a_v2_it = std::begin(amal.points);
 
-            // Disregard this edge if any of the verts are ficticious.
-            if( is_a_pseudo_vert(a_v1_it)
-            ||  is_a_pseudo_vert(a_v2_it) ){
-                continue;
-            }
 
             const auto a_end = std::end(amal.points);
             while(a_v2_it != a_end){
+                // Disregard this edge if any of the verts are ficticious.
+                if( is_a_pseudo_vert(a_v1_it)
+                ||  is_a_pseudo_vert(a_v2_it) ){
+                    YLOGWARN("We are here again!");
+                    a_v1_it = a_v2_it;
+                    ++a_v2_it;
+                    continue;
+                }
                 auto b_v1_it = std::prev(std::end(b_it->get().points));
                 auto b_v2_it = std::begin(b_it->get().points);
                 const auto b_end = std::end(b_it->get().points);


### PR DESCRIPTION
In his code, any N-to-N case where the seed contour had it's first closest edge pair be on contour point indices (end, 0) would result in an open mesh, with all but the first 2 contours completely disregarded in the branching, and no capping would be applied to all these contours either. This issue has been fixed.

Create custom contours updated to support multiple contours. Example arguments:
ROILabel = 'unspecified',
XValues = '0 1 1 0|0 1 1 0|0 1 1 0',
YValues = '0 0 1 1|0 0 1 1|0 0 1 1',
ZValues = '0 0 0 0|1 1 1 1|2 2 2',

(Each contour is separated by | as a delimiter and each point on a contour by a space)